### PR TITLE
Fix/statehandler

### DIFF
--- a/modules/prism_statehandler.php
+++ b/modules/prism_statehandler.php
@@ -413,7 +413,7 @@ class ClientHandler extends PropertyMaster
 	public function onTakeOverCar(IS_TOC $TOC)
 	{
 		# Makes a copy of the orginal, and adds it to the new client.
-		$this->parent->clients[$TOC->NewUCID]->players[$PLID] &= $this->parent->players[$TOC->PLID];
+		$this->parent->clients[$TOC->NewUCID]->players[$TOC->PLID] &= $this->parent->players[$TOC->PLID];
 		# Removes the copy from this class, but should not garbage collect it, because it's copyied in the new class.
 		unset($this->players[$TOC->PLID]);
 	}


### PR DESCRIPTION
2 simple fixes for the statehandler. Adds IS_NPL handling (after player state already exists), and fixes a missing object reference in IS_TOC handling.
