### PR TITLE
Fix PHP 7 compatibility with PLC defines & Adds missing function/typo

### DIFF
--- a/modules/prism_layoutobject.php
+++ b/modules/prism_layoutobject.php
@@ -337,11 +337,15 @@ class LayoutObject {
     }
     public function setY($y)
     {
-        $this->y = $y;;
+        $this->y = $y;
     }
     public function z()
     {
         return $this->z;
+    }
+    public function setZ($z)
+    {
+        $this->z = $z;
     }
     public function heading()
     {

--- a/modules/prism_packets.php
+++ b/modules/prism_packets.php
@@ -1152,27 +1152,27 @@ class IS_PLC extends Struct // PLayer Cars
     public $Cars;               # allowed cars - see below
 }; function IS_PLC() { return new IS_PLC; }
 
-define('PLC_UF1', '0x100');
-define('PLC_XFG', '1');
-define('PLC_XRG', '2');
-define('PLC_LX4', '0x20');
-define('PLC_LX6', '0x40');
-define('PLC_RB4', '8');
-define('PLC_FXO', '0x10');
-define('PLC_XRT', '4');
-define('PLC_RAC', '0x200');
-define('PLC_FZ5', '0x400');
-define('PLC_VWS', '0');
-define('PLC_UFR', '0x2000');
-define('PLC_XFR', '0x1000');
-define('PLC_FXR', '0x8000');
-define('PLC_XRR', '0x10000');
-define('PLC_FZR', '0x20000');
-define('PLC_MRT', '0x80');
-define('PLC_FBM', '0x80000');
-define('PLC_FOX', '0x800');
-define('PLC_FO8', '0x4000');
-define('PLC_BF1', '0x40000');
+define('PLC_UF1', 0x100);
+define('PLC_XFG', 1);
+define('PLC_XRG', 2);
+define('PLC_LX4', 0x20);
+define('PLC_LX6', 0x40);
+define('PLC_RB4', 8);
+define('PLC_FXO', 0x10);
+define('PLC_XRT', 4);
+define('PLC_RAC', 0x200);
+define('PLC_FZ5', 0x400);
+define('PLC_VWS', 0);
+define('PLC_UFR', 0x2000);
+define('PLC_XFR', 0x1000);
+define('PLC_FXR', 0x8000);
+define('PLC_XRR', 0x10000);
+define('PLC_FZR', 0x20000);
+define('PLC_MRT', 0x80);
+define('PLC_FBM', 0x80000);
+define('PLC_FOX', 0x800);
+define('PLC_FO8', 0x4000);
+define('PLC_BF1', 0x40000);
 
 
 // HANDICAPS


### PR DESCRIPTION
adds missing setZ() function to prism_layoutobject.php; also removes extraneous semi-colon